### PR TITLE
Add Renderers And Notion as Blog CMS

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@
 - [Websites and Communities](#websites-and-communities)
 - [Templates](#templates)
 - [Articles](#articles)
+- [Renderers](#renderers)
+- [Notion as Blog CMS](#notion-as-blog-cms)
 
 
 ## Tools
@@ -33,6 +35,16 @@
 ## Articles
 - [The NBA in Notion: A Practical Example of Databases](https://www.notion.vip/the-nba-in-notion-a-practical-example-of-databases/) - An article discussing how Notion databases work using an NBA database as an example.
 
+## Renderers
+- [React Notion](https://github.com/splitbee/react-notion) - A React renderer for Notion pages. Use Notion as CMS for blog, documentation or personal site.
+- [React Notion X](https://github.com/NotionX/react-notion-x) - Extended version of react-notion project. Support for more blocks of notes and provides more features, such as dark mode.
+- [Vue Notion](https://github.com/janniks/vue-notion) - A Vue renderer for Notion pages. Use Notion as CMS for blog, documentation or personal site, ported to vue from React Notion.
+
+## Notion as Blog CMS
+- [Notion Blog](https://github.com/ijjk/notion-blog) - It is a tool that uses Next.js to generate Notion as static blog web pages.
+- [Notablog](https://github.com/dragonman225/notablog) - Generate a minimalistic blog from Notion table.
+- [Next.js Notion Starter Kit](https://github.com/transitive-bullshit/nextjs-notion-starter-kit) - A starter kit using React Notion X to build into SSG with Next.js.
+- [React Notion Blog](https://github.com/splitbee/react-notion-blog) - Notion blog boilerplate using React Notion to build into SSG with Next.js.
 
 ## Contribute
 


### PR DESCRIPTION
I have added Notion renderers and Notion blog starter kits that use the frontend framework to make static web pages.

I named the section 'Renderer' and 'Notion as Blog CMS', but I don't know if this is appropriate. 
Please let me know if the section's location is not appropriate.

Thanks.