### PR TITLE
Add Notionsocial & Notion Social Preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ live in Notion pages
 - [TaskRobin](https://taskrobin.io/?utm_source=awesome-notion) - Save emails to Notion with 1-click.
 - [NotionApps](https://www.notionapps.com/?ref=awesome-notion) - Create powerful apps from Notion databases, without any coding.
 - [Simple Icons CDN](https://github.com/LitoMore/simple-icons-cdn) -  The CDN service of the free brand icons set for your Notion pages.
+- [NotionSocial](https://notionsocial.app/?ref=awesome-notion) - Schedule social media posts from Notion.
+- [Notion Social Preview](https://chrome.google.com/webstore/detail/notionsocial/hmekccbjjdndlipophapbddilacniidn) - Preview how your post will look like on social platforms, While planning it inside Notion.
 
 ## Websites and Communities
 


### PR DESCRIPTION
[Notionsocial](https://notionsocial.app/) is a social media scheduling tool built inside Notion.

[Notion Social Preview](https://chrome.google.com/webstore/detail/notionsocial/hmekccbjjdndlipophapbddilacniidn) let's users preview social media posts while editing inside Notion.