### PR TITLE
feat(mk-notes): add Mk Notes entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@
 
 ## Tools
 
+- [Mk Notes](https://github.com/Myastr0/mk-notes) - Sync your local Markdown files seamlessly to Notion, keep writing in Markdown and let Mk Notes handle the integration.
 - [Notis.ai](https://notis.ai) - Voice-powered copilot for Notion that captures, organizes, and finds anything in your Notion workspace - right from your favorite messaging app (WhatsApp, Telegram).
 - [Latwy](https://latwy.co) - Automatically sync your financial transactions and balances in Notion. 
 - [Heading Image Generator](https://engine.so/heading-image-generator-for-notion/) - Instantly create header graphics that you can easily copy/paste into Notion


### PR DESCRIPTION
# Description

This PR adds [mk-notes](https://github.com/Myastr0/mk-notes) to the Developer Tools / CLI section.

Mk Notes is an open-source CLI that allows users to seamlessly sync their local Markdown files to Notion. It’s designed to help developers and teams keep writing in Markdown while automatically handling the integration with Notion. 🔄


_As the maintainer of mk-notes, I believe it’s a valuable addition to the list of developer-oriented tools in the Notion ecosystem. It provides a simple, developer-friendly way to bridge Markdown workflows with Notion, which complements the other tools already featured here._