### PR TITLE
Add Notion CLI (andrzejchm) to Tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ live in Notion pages
 - [NotionSocial](https://notionsocial.app/?ref=awesome-notion) - Schedule social media posts from Notion.
 - [Notion Social Preview](https://chrome.google.com/webstore/detail/notionsocial/hmekccbjjdndlipophapbddilacniidn) - Preview how your post will look like on social platforms, While planning it inside Notion.
 - [Notion PDF](https://notionpdf.app) -  Print beautiful PDF documents from your Notion Page.
+- [Notion CLI](https://github.com/andrzejchm/notion-cli) - A terminal-based CLI for reading and writing Notion pages, querying databases, and managing content, built for AI coding agents and developers.
 - [Files to Notion](https://www.files2notion.com/) -  Organise and open your files directly from Notion
 - [Habit Genius](https://www.habit-genius.com/) - A Habit Tracker Widget for Notion
 - [Free widgets for Notion](https://www.laurieherault.com/free-notion-widget) Free widgets for Notion


### PR DESCRIPTION
Adds [Notion CLI](https://github.com/andrzejchm/notion-cli) to the Tools section.

TypeScript CLI for reading, writing, and managing Notion pages and databases from the terminal. Renders Notion pages as Markdown, queries databases with filters/sorting, pipes stdin into new pages, and supports multi-profile OAuth auth.

Different from the existing `4ier/notion-cli` entry (Go-based). This one is TypeScript/npm, has agent-friendly output modes (auto-detects TTY vs piped, `--json`), per-project `.notion.yaml` config, and stdin piping.