### PR TITLE
Add Notion URL to ID Raycast extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ live in Notion pages
 - [Whimsical](https://whimsical.com/) - Collaborative docs, flowcharts, wireframes, sticky notes, and mind maps.
 - [Indify](https://indify.co/) - Level up your Notion docs with widgets. Fully customizable, and seamless to set up.
 - [notionterm](https://github.com/ariary/notionterm) - Embed a shell in Notion pages.
-- [Notion URL to ID](https://github.com/samdsgn-studio/raycast-notion-id-extractor) - Raycast extension that extracts Notion page and database IDs from your browser or clipboard for APIs, automations, and embeds.
+- [Notion URL to ID](https://github.com/samdsgn-studio/raycast-notion-id-extractor) - Raycast extension that extracts Notion page and database IDs from URLs or the clipboard.
 - [NotionSender](https://notionsender.com/) - Create emails from notion pages.
 - [Butn.one](https://butn.one/) - Call-to-action button generator for Notion.
 - [TaskRobin](https://taskrobin.io/?utm_source=awesome-notion) - Save emails to Notion with 1-click.

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ live in Notion pages
 - [Whimsical](https://whimsical.com/) - Collaborative docs, flowcharts, wireframes, sticky notes, and mind maps.
 - [Indify](https://indify.co/) - Level up your Notion docs with widgets. Fully customizable, and seamless to set up.
 - [notionterm](https://github.com/ariary/notionterm) - Embed a shell in Notion pages.
+- [Notion URL to ID](https://github.com/samdsgn-studio/raycast-notion-id-extractor) - Raycast extension that extracts Notion page and database IDs from your browser or clipboard for APIs, automations, and embeds.
 - [NotionSender](https://notionsender.com/) - Create emails from notion pages.
 - [Butn.one](https://butn.one/) - Call-to-action button generator for Notion.
 - [TaskRobin](https://taskrobin.io/?utm_source=awesome-notion) - Save emails to Notion with 1-click.


### PR DESCRIPTION
Adds [Notion URL to ID](https://github.com/samdsgn-studio/raycast-notion-id-extractor) — a Raycast extension that extracts Notion page and database IDs from the browser or clipboard for APIs, automations, and embeds.

Contribution guidelines:
- Single suggestion in one PR
- Format: `[Resource](link) - Description.`
- Description ends with a period.